### PR TITLE
glue: uc-image: exit if model assertion is not set

### DIFF
--- a/glue/bin/uc-image
+++ b/glue/bin/uc-image
@@ -929,6 +929,10 @@ if [ -n "${BUILDER_CONFIG["PRESEED"]}" ]; then
   fi
 fi
 
+if [ -z ${BUILDER_CONFIG["MODEL_ASSERTION"]} ]; then
+  print_debug 0 "model_assertion is not set"
+  exit
+fi
 parse_model_asseertion
 [ -n "${DB_BUILDER_OUTPUT_DIR}" ] && BUILDER_CONFIG["OUTPUT_DIR"]=$(${READLINK} -f uci-${BUILDER_CONFIG["MODEL"]})
 


### PR DESCRIPTION
Hi,

I have been trying to build a core image with this tool recently, and there is one time I accidentally forget to add the model assertion as a argument, like this

```
$ uc-image -dd --build-raw --snap snapd=stable --disk-info buildstamp -O _out
```

then it will only print `parse_model_assertion` on the console and then will stuck forever

So I think it would be better to check whether user set the model assertion correctly or not, and exit the program if the model assertion is not set.