### PR TITLE
glue: u-boot-signed-cleardcd.imx needs to be exported for iMX6 based …

### DIFF
--- a/glue/bin/uc-image
+++ b/glue/bin/uc-image
@@ -43,7 +43,7 @@ BUILDER_CONFIG["SEARCH_PATH"]="${UC_IMAGE_SEARCH_PATH}"
 # gpt_* : partition table files
 # Qualcomm flash supporting files flashall, rawprogram*, patch*, prog_fire*
 # dragonboard 410c: sbc_1.0_8016.bin
-BUILDER_CONFIG["SPECIAL_GADGET_ASSETS"]="uc.lst gpt*.bin prog*_firehose*.* flashall rawprogram*.xml patch*.xml sbc_1.0_8016.bin u-boot-signed.* imx-boot.* bst_release.bin.signed reflash-system.sh"
+BUILDER_CONFIG["SPECIAL_GADGET_ASSETS"]="uc.lst gpt*.bin prog*_firehose*.* flashall rawprogram*.xml patch*.xml sbc_1.0_8016.bin u-boot-signed*.imx imx-boot.* bst_release.bin.signed reflash-system.sh"
 
 # delete all logs
 rm -rf $(dirname $(mktemp -u -t uc-image-builder-XXXX))/uc-image-builder-* 2> /dev/null


### PR DESCRIPTION
While flashing the iMX6 based devices, the following error is seen;

```
bugraaydogar@aydogar-ws:~/work/sugarland/x6-base-deploy$ sudo uuu uc.lst 
[sudo] password for bugraaydogar: 
uuu (Universal Update Utility) for nxp imx chips -- libuuu_1.4.69-0-g63b1d3c

Wait for Known USB Device Appear...
Error: fail open file: >u-boot-signed-cleardcd.imx
bugraaydogar@aydogar-ws:~/work/sugarland/x6-base-deploy$
```

`uc-image` tool does not export `u-boot-signed-cleardcd.imx` file in the output directory. This fix aims to solve it.
